### PR TITLE
processing options + configuring outputs, fixes

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,6 +18,8 @@ add_executable(tml
 	input.h
 	main.cpp
 	options.h
+	options.cpp
+	output.h
 	output.cpp
 	print_prolog.cpp
 	print_souffle.cpp

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -33,7 +33,7 @@ wostream& driver::print_ast(wostream& os) const {
 	cws s = 0;
 	for (auto n : ast::nodes) {
 		if (!s) s = n.r[0];
-		os << L"node(" << ast::name(n) << L' ' <<
+		os << ast::name(n) << L'(' <<
 			(n.r[0]-s) << L' ' << (n.r[1]-s) << L")." << endl;
 	}
 	return os.flush();
@@ -61,11 +61,11 @@ wostream& driver::print_ast_xml(wostream& os) const {
 	ast n = *nit;
 	cws s = n.r[0], r = n.r[1];
 	for (cws c = s; c != r; ++c, ++p) {
-		while ((n.r[0] - s) < p) n = *++nit;
+		while (nit != ast::nodes.end() && (n.r[0] - s) < p) n = *++nit;
 		while (!cls.empty() && cls.front() == p)
 			os << L"</" << stk.front() << L'>',
 			cls.pop_front(), stk.pop_front();
-		while ((n.r[0] - s) == p)
+		while (nit != ast::nodes.end() && (n.r[0] - s) == p)
 			os << L'<' << ast::name(n) << L'>',
 			stk.push_front(ast::name(n)), cls.push_front(n.r[1]-s),
 			n = *++nit;
@@ -83,11 +83,11 @@ wostream& driver::print_ast_html(wostream& os) const {
 	ast n = *nit;
 	cws s = n.r[0], r = n.r[1];
 	for (cws c = s; c != r; ++c, ++p) {
-		while ((n.r[0] - s) < p) n = *++nit;
+		while (nit != ast::nodes.end() && (n.r[0] - s) < p) n = *++nit;
 		while (!cls.empty() && cls.front() == p)
 			os<<L"</span>",
 			cls.pop_front();
-		while ((n.r[0] - s) == p)
+		while (nit != ast::nodes.end() && (n.r[0] - s) == p)
 			os<<L"<span class=\""<<ast::name(n)<<L"\">",
 			cls.push_front(n.r[1]-s),
 			n = *++nit;

--- a/src/defs.h
+++ b/src/defs.h
@@ -61,4 +61,6 @@ typedef std::vector<bools> vbools;
 template<typename T> T sort(const T& x){T t=x;return sort(t.begin(),t.end()),t;}
 void parse_error(std::wstring e, lexeme l);
 struct lexcmp { bool operator()(const lexeme& x, const lexeme& y) const; };
+std::wstring s2ws(const std::string&);
+std::string  ws2s(const std::wstring&);
 #endif

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -247,7 +247,7 @@ void driver::init() {
 driver::driver(int argc, char** argv, raw_progs rp, options o) : argc(argc),
 	argv(argv), opts(o) {
 	opts.parse(argc, argv);
-	DBG(wcout<<L"parsed args: "<<opts<<endl;)
+//	DBG(wcout<<L"parsed args: "<<opts<<endl;)
 	strs_t strtrees;
 	output_ast();
 	for (size_t n = 0; n != rp.p.size(); ++n) {
@@ -255,7 +255,7 @@ driver::driver(int argc, char** argv, raw_progs rp, options o) : argc(argc),
 		DBG(if(opts.enabled(L"o"))tbl.out(output::to(L"output")<<endl);)
 	}
 	NDBG(if (opts.enabled(L"o")) tbl.out(output::to(L"output")<<endl);)
-	if (opts.enabled(L"csv")) wcout<<L"opts.enabled(csv) = true"<<endl, save_csv();
+	if (opts.enabled(L"csv")) save_csv();
 }
 
 driver::driver(int argc, char** argv, FILE *f, options o) :

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -121,7 +121,14 @@ size_t driver::load_stdin() {
 //	return r;
 }*/
 
-wstring s2ws(const string& s) { return wstring(s.begin(), s.end()); } // FIXME
+wstring s2ws(const std::string& s) {
+	return std::wstring_convert<std::codecvt_utf8<wchar_t>>().from_bytes(s);
+}
+
+string ws2s(const wstring& s) {
+	return std::wstring_convert<std::codecvt_utf8<wchar_t>>().to_bytes(s);
+}
+
 void unquote(wstring& str);
 
 wstring driver::directive_load(const directive& d) {
@@ -185,7 +192,7 @@ void driver::transform(raw_progs& rp, size_t n, const strs_t& strtrees) {
 			dict.get_rel(pd.strs.begin()->first),
 			pd.strs.begin()->second.size());
 	}
-	if (opts.ms)
+	if (opts.enabled(L"ms"))
 		for (raw_prog& p : rp.p)
 			p = transform_ms(p);
 //	if (trel[0]) transform_proofs(rp.p[n], trel);
@@ -193,30 +200,17 @@ void driver::transform(raw_progs& rp, size_t n, const strs_t& strtrees) {
 //	if (pd.bwd) rp.p.push_back(transform_bwd(rp.p[n]));
 }
 
-const string tmp(const string ext) {
-	string fname(tmpnam(0)); fname += ext;
-	wcerr << L"Saving " << s2ws(fname) << endl;
-	return fname;
-}
-#define tmp_os(ext) wofstream os(tmp(ext))
-
 void driver::output_pl(const raw_prog& p) const {
-	for (auto d : opts.dialects) switch (d) {
-		case XSB:   { tmp_os(".P");  print_xsb(os, p);   }; break;
-		case SWIPL: { tmp_os(".pl"); print_swipl(os, p); }; break;
-		case SOUFFLE: { tmp_os(".souffle"); print_souffle(os, p);}break;
-		default: ;
-	}
+	if (opts.enabled(L"xsb"))     print_xsb    (output::to(L"xsb"),     p);
+	if (opts.enabled(L"swipl"))   print_swipl  (output::to(L"swipl"),   p);
+	if (opts.enabled(L"souffle")) print_souffle(output::to(L"souffle"), p);
 }
 
 void driver::output_ast() const {
-	for (auto t : opts.ast_formats) switch (t) {
-		case AST_TML:  {tmp_os(".ast.tml");  print_ast(os); } break;
-		case AST_JSON: {tmp_os(".ast.json"); print_ast_json(os);} break;
-		case AST_XML:  {tmp_os(".ast.xml");  print_ast_xml(os); } break;
-		case AST_HTML: {tmp_os(".ast.html"); print_ast_html(os);} break;
-		default: ;
-	}
+	if (opts.enabled(L"ast"))      print_ast     (output::to(L"ast"));
+	if (opts.enabled(L"ast-json")) print_ast_json(output::to(L"ast-json"));
+	if (opts.enabled(L"ast-xml"))  print_ast_xml (output::to(L"ast-xml"));
+	if (opts.enabled(L"ast-html")) print_ast_html(output::to(L"ast-html"));
 	ast::clear();
 }
 
@@ -225,10 +219,11 @@ void driver::prog_run(raw_progs& rp, size_t n, strs_t& strtrees) {
 	//DBG(wcout << L"original program:"<<endl<<p;)
 	transform(rp, n, strtrees);
 	output_pl(rp.p[n]);
-	if (opts.enabled_dialect(TRANSFORMED))
+	if (opts.enabled(L"t"))
 		for (auto p : rp.p)
-			wcout<<L'{'<<endl<<p<<L'}'<<endl;
+			output::to(L"transformed")<<L'{'<<endl<<p<<L'}'<<endl;
 //	strtrees.clear(), get_dict_stats(rp.p[n]), add_rules(rp.p[n]);
+	if (opts.disabled(L"run")) return;
 	clock_t start, end;
 	measure_time(tbl.run_prog(rp.p[n]));
 //	for (auto x : prog->strtrees_out)
@@ -237,27 +232,38 @@ void driver::prog_run(raw_progs& rp, size_t n, strs_t& strtrees) {
 //	int_t tr = dict.get_rel(L"try");
 }
 
+void driver::init() {
+	output::create(L"output",      L".out.tml");
+	output::create(L"transformed", L".trans.tml");
+	output::create(L"xsb",         L".P");
+	output::create(L"swipl",       L".pl");
+	output::create(L"souffle",     L".souffle");
+	output::create(L"ast",         L".ast.tml");
+	output::create(L"ast-json",    L".ast.json");
+	output::create(L"ast-xml",     L".ast.xml");
+	output::create(L"ast-html",    L".ast.html");
+}
+
 driver::driver(int argc, char** argv, raw_progs rp, options o) : argc(argc),
 	argv(argv), opts(o) {
 	opts.parse(argc, argv);
+	DBG(wcout<<L"parsed args: "<<opts<<endl;)
 	strs_t strtrees;
 	output_ast();
 	for (size_t n = 0; n != rp.p.size(); ++n) {
 		prog_run(rp, n, strtrees);
-		DBG(tbl.out(wcout<<endl);)
+		DBG(if(opts.enabled(L"o"))tbl.out(output::to(L"output")<<endl);)
 	}
-	NDBG(if (opts.enabled_format(F_TML)) tbl.out(wcout<<endl);)
-	if (opts.enabled_format(F_CSV)) save_csv();
+	NDBG(if (opts.enabled(L"o")) tbl.out(output::to(L"output")<<endl);)
+	if (opts.enabled(L"csv")) wcout<<L"opts.enabled(csv) = true"<<endl, save_csv();
 }
-
-std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t> converter;
 
 driver::driver(int argc, char** argv, FILE *f, options o) :
 	driver(argc, argv, raw_progs(f), o) {}
 driver::driver(int argc, char** argv, wstring s, options o) :
 	driver(argc, argv, raw_progs(s), o) {}
 driver::driver(int argc, char** argv, char *s, options o) :
-	driver(argc, argv, raw_progs(converter.from_bytes(string(s))), o) {}
+	driver(argc, argv, raw_progs(s2ws(string(s))), o) {}
 driver::driver(int argc, char** argv, FILE *f) :
 	driver(argc, argv, f, options()) {}
 driver::driver(int argc, char** argv, wstring s) :

--- a/src/driver.h
+++ b/src/driver.h
@@ -14,7 +14,10 @@
 #include "tables.h"
 #include "input.h"
 #include "dict.h"
+#include "output.h"
 #include "options.h"
+
+typedef enum prolog_dialect { XSB, SWIPL } prolog_dialect;
 
 struct prog_data {
 	strs_t strs;
@@ -78,6 +81,7 @@ class driver {
 public:
 	bool result = true;
 	options opts;
+	static void init();
 	driver(int argc, char** argv, FILE *f, options o);
 	driver(int argc, char** argv, std::wstring, options o);
 	driver(int argc, char** argv, char *s, options o);
@@ -90,7 +94,7 @@ public:
 //	std::wostream& printbdd_one(std::wostream& os, spbdd t, size_t bits,
 //		const prefix&) const;
 	std::wostream& print_prolog(std::wostream&, const raw_prog&,
-		const dialect) const;
+		const prolog_dialect) const;
 	std::wostream& print_xsb(std::wostream&, const raw_prog&) const;
 	std::wostream& print_swipl(std::wostream&, const raw_prog&) const;
 	std::wostream& print_souffle(std::wostream&, const raw_prog&) const;

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -349,7 +349,6 @@ off_t fsize(const char *fname) {
 	return stat(fname, &s) ? 0 : s.st_size;
 }
 
-string ws2s(const wstring& s) { return string(s.begin(), s.end()); }
 off_t fsize(cws s, size_t len) { return fsize(ws2s(wstring(s, len)).c_str()); }
 
 wstring file_read(wstring fname) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,6 +19,7 @@ using namespace std;
 int main(int argc, char** argv) {
 	setlocale(LC_ALL, "");
 	bdd::init();
+	driver::init(); // setup outputs
 	driver d(argc, argv, stdin);
 	if (!d.result) wcout << "unsat" << endl;
 //	print_memos_len();

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1,0 +1,138 @@
+// LICENSE
+// This software is free for use and redistribution while including this
+// license notice, unless:
+// 1. is used for commercial or non-personal purposes, or
+// 2. used for a product which includes or associated with a blockchain or other
+// decentralized database technology, or
+// 3. used for a product which includes or associated with the issuance or use
+// of cryptographic or electronic currencies/coins/tokens.
+// On all of the mentioned cases, an explicit and written permission is required
+// from the Author (Ohad Asor).
+// Contact ohad@idni.org for requesting a permission. This license may be
+// modified over time by the Author.
+#include "options.h"
+
+using namespace std;
+
+void options::add(option o) {
+	set(o.name(), o);
+	for (auto n : o.names()) alts[n] = o.name();
+}
+
+bool options::get(const wstring name, option& o) const {
+	auto ait = alts.find(name);        if (ait == alts.end()) return false;
+	auto oit = opts.find(ait->second); if (oit == opts.end()) return false;
+	return o = oit->second, true;
+}
+
+int options::get_int(wstring name) const {
+	option o; return get(name, o) ? o.get_int() : 0;
+}
+
+bool options::get_bool(wstring name) const {
+	option o; return get(name, o) ? o.get_bool() : false;
+}
+
+wstring options::get_string(wstring name) const {
+	option o; return get(name, o) ? o.get_string() : L"";
+}
+
+void options::parse(int argc, char** argv) {
+	wstrings wargs = {};
+	for (int i = 1; i < argc; ++i)
+		wargs.push_back(s2ws(string(argv[i])));
+	parse(wargs);
+}
+
+void options::parse(strings args) {
+	wstrings wargs = {};
+	for (size_t i=0; i < wargs.size(); ++i) wargs.push_back(s2ws(args[i]));
+	parse(wargs);
+}
+
+void options::parse(wstrings args) {
+	wstring v;
+	for (size_t i = 0; i < args.size(); ++i) {
+		v = (i < args.size()-1) ? try_read_value(args[i+1]) : L"";
+		parse_option(args[i], v);
+		if (v != L"") i++;
+	}
+}
+
+bool options::enabled(const wstring name) const {
+	option o;
+	if (!get(name, o)) return false;
+	switch (o.get_type()) {
+		case option::type::BOOL:   return o.get_bool();
+		case option::type::INT:    return o.get_int() > 0;
+		case option::type::STRING: {
+			return output::exists(o.name())
+				? !output::is_null(o.name())
+				: o.get_string() != L"";
+		}
+		default: ;
+	}
+	return false;
+}
+
+wstring options::try_read_value(wstring v) {
+	if (v == L"-") return L"@stdout";
+	if (v.rfind(L"---", 0) == 0) return v.substr(2);
+	return v[0] == L'-' ? L"" : v;
+}
+
+void options::parse_option(wstring arg, wstring v) {
+	option o;
+	bool disabled = false;
+	size_t pos = 0;
+	// skip hyphens
+	while (pos < arg.length() && arg[pos] == L'-' && pos < 2) ++pos;
+	wstring a = arg.substr(pos);
+	// is option disabled?
+	if (a.rfind(L"disable-",   0) == 0) disabled = true, a = a.substr(8);
+	else if (a.rfind(L"dont-", 0) == 0) disabled = true, a = a.substr(5);
+	else if (a.rfind(L"no-",   0) == 0) disabled = true, a = a.substr(3);
+	if (!get(a, o)) return;
+	if (disabled) o.disable();
+	else o.parse_value(v);
+	set(o.name(), o);
+}
+
+#define add_output(n) add(option(option::type::STRING, {n}, \
+		[](const option::value& v) { \
+			output::set_target(n,v.get_string());}))
+#define add_output_alt(n, alt) add(option(option::type::STRING, {n, alt}, \
+		[](const option::value& v) { \
+			output::set_target(n,v.get_string());}))
+
+void options::setup() {
+
+	add(option(option::type::BOOL,   { L"ms" }));
+	add(option(option::type::BOOL,   { L"run" }));
+	add(option(option::type::BOOL,   { L"csv" }));
+	add(option(option::type::STRING, { L"name", L"n" },
+		[](const option::value& v) {
+			output::set_name(v.get_string());
+		}));
+	add_output_alt(L"output",      L"o");
+	add_output_alt(L"transformed", L"t");
+	add_output_alt(L"ast",         L"at");
+	add_output_alt(L"ast-json",    L"aj");
+	add_output_alt(L"ast-xml",     L"ax");
+	add_output_alt(L"ast-html",    L"ah");
+	add_output    (L"xsb");
+	add_output    (L"swipl");
+	add_output    (L"souffle");
+
+	init_defaults();
+}
+
+#undef add_output
+#undef add_output_alt
+
+void options::init_defaults() {
+	parse({
+		L"--run", L"true",
+		L"--output", L"@stdout"
+	});
+}

--- a/src/options.h
+++ b/src/options.h
@@ -10,48 +10,122 @@
 // from the Author (Ohad Asor).
 // Contact ohad@idni.org for requesting a permission. This license may be
 // modified over time by the Author.
-#include <algorithm>
-#include <string>
-#include <set>
+#ifndef __OPTIONS_H__
+#define __OPTIONS_H__
+#include <functional>
+#include "defs.h"
+#include "output.h"
 
-typedef enum dialect { TRANSFORMED, XSB, SWIPL, SOUFFLE } dialect;
-typedef enum format { F_TML, F_CSV } format;
-typedef enum ast_format { AST_TML, AST_JSON, AST_XML, AST_HTML } ast_format;
+typedef std::vector<std::string> strings;
+typedef std::vector<std::wstring> wstrings;
 
-#define if_opt(o)       if (option(arg, (o)))
-#define if_opts(o1, o2) if (option(arg, (o1)) || option(arg, (o2)))
-
-struct options {
-	std::set<format> formats = { F_TML };
-	bool ms = false;
-	std::set<dialect> dialects = {};
-	std::set<ast_format> ast_formats = {};
-	options() {}
-	options(int argc, char** argv) { parse(argc, argv); }
-	void parse(int c, char** v) {
-		for (int i = 1; i < c; ++i) {
-			std::string arg = std::string(v[i]);
-			if_opts("t", "transformed")dialects.insert(TRANSFORMED);
-			else if_opt("xsb")         dialects.insert(XSB);
-			else if_opt("swipl")       dialects.insert(SWIPL);
-			else if_opt("souffle")     dialects.insert(SOUFFLE);
-			else if_opt("csv")         formats.insert(F_CSV);
-			else if_opt("ast")         ast_formats.insert(AST_TML);
-			else if_opt("ast-json")    ast_formats.insert(AST_JSON);
-			else if_opt("ast-xml")     ast_formats.insert(AST_XML);
-			else if_opt("ast-html")    ast_formats.insert(AST_HTML);
-			else if_opt("ms")	   ms = true;
+struct option {
+	enum type { UNDEFINED, INT, BOOL, STRING };
+	struct value {
+		value()               : t(UNDEFINED)         {}
+		value(int i)          : t(INT),      v_i(i)  {}
+		value(bool b)         : t(BOOL),     v_b(b)  {}
+		value(std::wstring s) : t(STRING),   v_s(s)  {}
+		void set(int i)          { t=INT;    v_i = i; }
+		void set(bool b)         { t=BOOL;   v_b = b; }
+		void set(std::wstring s) { t=STRING; v_s = s; }
+		void null() {
+			switch (t) {
+				case INT:    v_i = 0; break;
+				case BOOL:   v_b = false; break;
+				case STRING: v_s = L""; break;
+				default: ;
+			}
 		}
+		type get_type() const { return t; }
+		int                 get_int()    const { return v_i; }
+		bool                get_bool()   const { return v_b; }
+		const std::wstring& get_string() const { return v_s; }
+		bool is_undefined() const { return t == UNDEFINED; }
+		bool is_int()       const { return t == INT; }
+		bool is_bool()      const { return t == BOOL; }
+		bool is_string()    const { return t == STRING; }
+		bool operator ==(const value& ov) const {
+			if (t != ov.get_type()) return false;
+			switch (t) {
+				case UNDEFINED: return ov.is_undefined();
+				case INT:       return v_i == ov.get_int();
+				case BOOL:      return v_b == ov.get_bool();
+				case STRING:    return v_s == ov.get_string();
+			}
+		}
+	private:
+		type         t;
+		int          v_i = 0;
+		bool         v_b = false;
+		std::wstring v_s = L"";
+	};
+	typedef std::function<void(const value&)> callback;
+	option() {}
+	option(type t, wstrings n, callback e, option::value v={})
+		: t(t), n(n), v(v), e(e) {}
+	option(type t, wstrings n, option::value v={})
+		: t(t), n(n), v(v), e(0) {}
+	const std::wstring& name() const { return n[0]; }
+	const wstrings& names() const { return n; }
+	type get_type() const { return t; }
+	value get() const { return v; }
+	int           get_int   () const { return v.get_int(); };
+	bool          get_bool  () const { return v.get_bool(); };
+	std::wstring  get_string() const { return v.get_string(); };
+	bool operator ==(const value& ov) const { return v == ov; }
+	bool operator ==(const option& o) const { return n == o.names(); }
+	bool operator  <(const option& o) const { return n < o.names(); }
+	void parse_value(std::wstring s) {
+		//DBG(std::wcout << L"option::parse_value(s=\"" << s <<
+		//	L"\") <" << (int)t << L'>' << std::endl;)
+		switch (t) {
+			case INT: if (s != L"") v.set(std::stoi(s)); break;
+			case BOOL: v.set(s==L"" || s==L"true" || s==L"t" ||
+				s==L"1" || s==L"on" || s==L"enabled"); break;
+			case STRING: if (s != L"") v.set(s); break;
+			default: throw 0;
+		}
+		if (e) e(v);
 	}
-	bool option(const std::string arg, const std::string o) const {
-		return (arg == "--"+o || arg == "-"+o);
-	}
-	template<typename T>bool enabled(const std::set<T> &s, const T &o)const{
-		auto it = std::find (s.begin(), s.end(), o);
-		return (it != s.end());
-	}
-	bool enabled_dialect(const dialect d)const {return enabled(dialects,d);}
-	bool enabled_format(const format f) const  { return enabled(formats,f);}
-	bool enabled_ast_format(ast_format t) const {
-		return enabled(ast_formats, t); }
+	void disable() { v.null(); }
+	bool is_undefined() const { return v.is_undefined(); }
+private:
+	type t;
+	wstrings n; // vector of name and alternative names (shortcuts)
+	value v;
+	callback e; // callback with value as argument, fired when option parsed
 };
+
+class options {
+	friend std::wostream& operator<<(std::wostream&, const options&);
+	std::map<std::wstring, option> opts = {};
+	std::map<std::wstring, std::wstring> alts = {};
+	std::wstring try_read_value(std::wstring v);
+	void parse_option(std::wstring arg, std::wstring v = L"");
+	void setup();
+	void init_defaults();
+public:
+	options()                      { setup(); }
+	options(int argc, char** argv) { setup(); parse(argc, argv); }
+	options(strings args)          { setup(); parse(args); }
+	options(wstrings args)         { setup(); parse(args); }
+	void add(option o);
+	bool get(std::wstring name, option& o) const;
+	void set(const std::wstring name, const option o) {
+		opts.insert_or_assign(name, o);
+	}
+	void parse(int argc, char** argv);
+	void parse(strings args);
+	void parse(wstrings args);
+	bool enabled (const std::wstring arg) const;
+	bool disabled(const std::wstring arg) const { return !enabled(arg); }
+	int           get_int   (std::wstring name) const;
+	bool          get_bool  (std::wstring name) const;
+	std::wstring  get_string(std::wstring name) const;
+};
+
+std::wostream& operator<<(std::wostream&, const std::map<std::wstring,option>&);
+std::wostream& operator<<(std::wostream&, const option&);
+std::wostream& operator<<(std::wostream&, const options&);
+#endif

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -15,6 +15,10 @@
 #include <sstream>
 using namespace std;
 
+wostream wcnull(0);
+map<std::wstring, output> output::outputs = {};
+wstring output::named = L"";
+
 wostream& operator<<(wostream& os, const pair<cws, size_t>& p) {
 	for (size_t n = 0; n != p.second; ++n) os << p.first[n];
 	return os;
@@ -221,4 +225,45 @@ wostream& operator<<(wostream& os, const raw_progs& p) {
 	if (p.p.size() == 1) os << p.p[0];
 	else for (auto x : p.p) os << L'{' << endl << x << L'}' << endl;
 	return os;
+}
+
+wostream& operator<<(wostream& os, const output& o) {
+	return os << o.target();
+}
+
+wostream& operator<<(wostream& os, const option& o) {
+	if (o.is_undefined()) return os;
+	os << L"--" << o.name() << L' ';
+	switch (o.get_type()) {
+		case option::type::INT: {
+			int i = o.get_int();
+			return os << (i < 0 ? L"--":L"") << i;
+		}
+		case option::type::BOOL:
+			return os << (o.get_bool() ?L"":L"false");
+		case option::type::STRING: {
+			wstring s = o.get_string();
+			if (s.rfind(L"-", 0) == 0) os << L"--";
+			os << L'"';
+			for (auto it = s.begin(); it < s.end(); ++it)
+				os << (*it == '\\' || *it == '"' ? L"\\" : L""),
+				os << *it;
+			return os << L'"';
+		} break;
+		default: ;
+	}
+	return os;
+}
+
+wostream& operator<<(wostream& os, const std::map<std::wstring,option>& opts) {
+	bool t = false;
+	for (auto it : opts) {
+		if (!it.second.is_undefined())
+			os << (t ? L" " : L"") << it.second, t = true;
+	}
+	return os;
+}
+
+wostream& operator<<(wostream& os, const options& o) {
+	return os << o.opts;
 }

--- a/src/output.h
+++ b/src/output.h
@@ -1,0 +1,108 @@
+// LICENSE
+// This software is free for use and redistribution while including this
+// license notice, unless:
+// 1. is used for commercial or non-personal purposes, or
+// 2. used for a product which includes or associated with a blockchain or other
+// decentralized database technology, or
+// 3. used for a product which includes or associated with the issuance or use
+// of cryptographic or electronic currencies/coins/tokens.
+// On all of the mentioned cases, an explicit and written permission is required
+// from the Author (Ohad Asor).
+// Contact ohad@idni.org for requesting a permission. This license may be
+// modified over time by the Author.
+#ifndef __OUTPUT_H__
+#define __OUTPUT_H__
+#include <string>
+#include <sstream>
+#include <map>
+#include <fstream>
+
+std::wstring s2ws(const std::string&);
+std::string  ws2s(const std::wstring&);
+
+extern std::wostream wcnull;
+
+class output {
+	static std::map<std::wstring, output*> outputs;
+	static std::wstring named; // filename w/o ext (used for @name)
+	std::wstring n = L"";      // name of the output stream
+	std::wstring e = L"";      // filename extension
+	std::wstring t = L"@null"; // target
+	std::wstring f;            // filename
+	std::wostream* s;          // output stream
+	std::wostream& os(std::wostream* wos) {
+		return s = wos, *s;
+	}
+	std::wstring tmpfile() {
+		std::wstring fn = s2ws(tmpnam(0)) + e;
+		std::wcerr << fn << L" # " << n <<std::endl;
+		return fn;
+	}
+	static output* add(output* o) { return outputs[o->name()] = o; }
+	output(std::wstring n, std::wstring e) : n(n), e(e) {
+		add(this);
+	}
+public:
+	static output* create(std::wstring n, std::wstring e,
+		std::wstring t = L"") {
+		output* o = new output(n, e);
+		if (t != L"") o->target(t);
+		return o;
+	}
+	static const std::wstring& set_name(const std::wstring fn = L"") {
+		return named = fn;
+	}
+	static output* get(const std::wstring nam) {
+		auto it = outputs.find(nam);
+		if (it == outputs.end()) return 0;
+		return it->second;
+	}
+	static std::wostream& to(const std::wstring nam) {
+		output *o = get(nam);
+		if (!o || !o->s) return wcnull;
+		return *o->s;
+	}
+	static std::wstring get_target(const std::wstring nam) {
+		output *o = get(nam);
+		return o ? o->target() : L"@null";
+	}
+	static bool is_null(const std::wstring nam) {
+		output *o = get(nam);
+		return !o || o->is_null();
+	}
+	static std::wstring file(const std::wstring nam) {
+		output *o = get(nam);
+		return o ? o->filename() : L"";
+	}
+	static std::wstring read(std::wstring nam) {
+		output *o = get(nam);
+		return o && o->target() == L"@buffer"
+			? ((std::wstringstream*)o->s)->str() : L"";
+	}
+	output() {}
+	std::wstring name() const { return n; }
+	std::wstring filename() const { return f; }
+	std::wstring filename(const std::wstring fn) { return f = fn; }
+	std::wostream& os() const { return *s; }
+	std::wstring target() const { return t; }
+	std::wostream& target(const std::wstring tar) {
+		t = tar == L"" ? L"@stdout" : tar;
+		if (t==L"@null")   return os(&wcnull);
+		if (t==L"@stdout") return os(&std::wcout);
+		if (t==L"@stderr") return os(&std::wcerr);
+		if (t==L"@buffer") return os(new std::wstringstream());
+		if ((t==L"@name" && named==L"") ||
+			 t==L"@tmp")  filename(tmpfile());
+		else if (t==L"@name") filename(named+e);
+		else                  filename(t);
+		return os(new std::wofstream(ws2s(filename())));
+	}
+	bool is_null() const {
+		return t == L"@null" || outputs.find(n) == outputs.end();
+	}
+	bool operator ==(const output& o) const {
+		return n == o.n && filename() == o.filename();
+	}
+	bool operator <(const output& o) const { return n < o.n; }
+};
+#endif

--- a/src/output.h
+++ b/src/output.h
@@ -16,9 +16,7 @@
 #include <sstream>
 #include <map>
 #include <fstream>
-
-std::wstring s2ws(const std::string&);
-std::string  ws2s(const std::wstring&);
+#include "defs.h"
 
 extern std::wostream wcnull;
 
@@ -41,10 +39,17 @@ public:
 	static const std::wstring& set_name(const std::wstring fn = L"") {
 		return named = fn;
 	}
+	static bool exists(const std::wstring nam) {
+		auto it = outputs.find(nam);
+		return it != outputs.end();
+	}
 	static bool get(const std::wstring nam, output& o) {
 		auto it = outputs.find(nam);
 		if (it == outputs.end()) return false;
 		return o = it->second, true;
+	}
+	static void set(const std::wstring nam, output o) {
+		outputs.insert_or_assign(nam, o);
 	}
 	static std::wostream& to(const std::wstring nam) {
 		output o;
@@ -53,6 +58,13 @@ public:
 	static std::wstring get_target(const std::wstring nam) {
 		output o;
 		return get(nam, o) ? o.target() : L"@null";
+	}
+	static std::wostream& set_target(const std::wstring nam,
+						const std::wstring tar) {
+		output o;
+		if (!get(nam, o)) return wcnull;
+		std::wostream& os = o.target(tar);
+		return set(nam, o), os;
 	}
 	static bool is_null(const std::wstring nam) {
 		output o;

--- a/src/output.test.cpp
+++ b/src/output.test.cpp
@@ -1,0 +1,139 @@
+#include <string>
+#include <iostream>
+#include <locale>
+#include <codecvt>
+#include <map>
+#include "defs.h"
+#include "output.h"
+
+using namespace std;
+wostream wcnull(0);
+map<std::wstring, output*> output::outputs = {};
+wstring output::named = L"";
+
+wostream& operator<<(wostream& os, const output& o) {
+	return os << o.target();
+}
+
+wstring s2ws(const std::string& s) {
+	return std::wstring_convert<std::codecvt_utf8<wchar_t>>()
+		.from_bytes(s);
+}
+string ws2s(const wstring& s) {
+	return std::wstring_convert<std::codecvt_utf8<wchar_t>>()
+		.to_bytes(s);
+}
+
+int main() {
+
+	// create various outputs
+	output::create(L"null",     L".null",   L"@null");
+	output::create(L"output",   L".out",    L"@stdout");
+	output::create(L"errors",   L".err",    L"@stderr");
+	output::create(L"buffer",   L".buff",   L"@buffer");
+	output::create(L"tmp",      L".tmp",    L"@tmp");
+	output::create(L"file",     L".file",   L"test.file");
+	output::create(L"noname", L".noname", L"@name");
+	output::set_name(L"named");
+	output::create(L"name1",    L".name1",  L"@name");
+	output::create(L"name2",    L".name2",  L"@name");
+
+	// output to null
+	output::to(L"null") << L"null test" << endl;
+
+	// output to stdout
+	output::to(L"output") << L"stdout test" << endl;
+
+	// output to stderr
+	output::to(L"errors") << L"stderr test" << endl;
+
+	// output to buffer
+	output::to(L"buffer") << L"buffer test";
+	// read buffer content
+	wcout<<L"buffer content: \""<<output::read(L"buffer")<<L'"'<<endl;
+	assert(output::read(L"buffer") == L"buffer test");
+
+	// output to tmp file
+	output::to(L"tmp") << L"tmp test" << endl;
+
+	// output to file
+	output::to(L"file") << L"file test" << endl;
+
+	// output to named file w/o specifying the name => tmp file
+	output::to(L"noname") << L"noname test" << endl;
+
+	// output to named files
+	output::to(L"name1") << L"named1 test" << endl;
+	output::to(L"name2") << L"named2 test" << endl;
+
+	// get known
+	wcout<<L"get returns output*: "<<output::get(L"output")<<endl;
+	assert(output::get(L"output"));
+
+	// get unkown
+	wcout<<L"get unknown output: "<<output::get(L"not created")<<endl;
+	assert(!output::get(L"not created"));
+
+	// get filename outputs target to
+	wcout << L"outputs to files:" << endl;
+	wcout << L"\t null: "   << output::file(L"null")   << endl;
+	wcout << L"\t output: " << output::file(L"output") << endl;
+	wcout << L"\t errors: " << output::file(L"errors") << endl;
+	wcout << L"\t buffer: " << output::file(L"buffer") << endl;
+	wcout << L"\t tmp: "    << output::file(L"tmp")    << endl;
+	wcout << L"\t noname: " << output::file(L"noname") << endl;
+	wcout << L"\t name1: "  << output::file(L"name1")  << endl;
+	wcout << L"\t name2: "  << output::file(L"name2")  << endl;
+	wcout << L"\t file: "   << output::file(L"file")   << endl;
+	assert(output::file(L"null")   == L"");
+	assert(output::file(L"output") == L"");
+	assert(output::file(L"errors") == L"");
+	assert(output::file(L"buffer") == L"");
+	assert(output::file(L"tmp")    != L"");
+	assert(output::file(L"noname") != L"");
+	assert(output::file(L"name1")  == L"named.name1");
+	assert(output::file(L"name2")  == L"named.name2");
+	assert(output::file(L"file")   == L"test.file");
+
+	// is null
+	wcout << L"is_null?:" << endl;
+	wcout << L"\t null: "   << output::is_null(L"null")   << endl;
+	wcout << L"\t output: " << output::is_null(L"output") << endl;
+	wcout << L"\t errors: " << output::is_null(L"errors") << endl;
+	wcout << L"\t buffer: " << output::is_null(L"buffer") << endl;
+	wcout << L"\t tmp: "    << output::is_null(L"tmp")    << endl;
+	wcout << L"\t noname: " << output::is_null(L"noname") << endl;
+	wcout << L"\t name1: "  << output::is_null(L"name1")  << endl;
+	wcout << L"\t name2: "  << output::is_null(L"name2")  << endl;
+	wcout << L"\t file: "   << output::is_null(L"file")   << endl;
+	assert( output::is_null(L"null"));
+	assert(!output::is_null(L"output"));
+	assert(!output::is_null(L"errors"));
+	assert(!output::is_null(L"buffer"));
+	assert(!output::is_null(L"tmp"));
+	assert(!output::is_null(L"noname"));
+	assert(!output::is_null(L"name1"));
+	assert(!output::is_null(L"name2"));
+	assert(!output::is_null(L"file"));
+
+	// get targets
+	wcout << L"targets:" << endl;
+	wcout << L"\t null: "   << output::get_target(L"null")   << endl;
+	wcout << L"\t output: " << output::get_target(L"output") << endl;
+	wcout << L"\t errors: " << output::get_target(L"errors") << endl;
+	wcout << L"\t buffer: " << output::get_target(L"buffer") << endl;
+	wcout << L"\t tmp: "    << output::get_target(L"tmp")    << endl;
+	wcout << L"\t noname: " << output::get_target(L"noname") << endl;
+	wcout << L"\t name1: "  << output::get_target(L"name1")  << endl;
+	wcout << L"\t name2: "  << output::get_target(L"name2")  << endl;
+	wcout << L"\t file: "   << output::get_target(L"file")   << endl;
+	assert(output::get_target(L"null")   == L"@null");
+	assert(output::get_target(L"output") == L"@stdout");
+	assert(output::get_target(L"errors") == L"@stderr");
+	assert(output::get_target(L"buffer") == L"@buffer");
+	assert(output::get_target(L"tmp")    == L"@tmp");
+	assert(output::get_target(L"noname") == L"@name");
+	assert(output::get_target(L"name1")  == L"@name");
+	assert(output::get_target(L"name2")  == L"@name");
+	assert(output::get_target(L"file")   == L"test.file");
+}

--- a/src/output.test.cpp
+++ b/src/output.test.cpp
@@ -8,7 +8,7 @@
 
 using namespace std;
 wostream wcnull(0);
-map<std::wstring, output*> output::outputs = {};
+map<std::wstring, output> output::outputs = {};
 wstring output::named = L"";
 
 wostream& operator<<(wostream& os, const output& o) {
@@ -16,12 +16,11 @@ wostream& operator<<(wostream& os, const output& o) {
 }
 
 wstring s2ws(const std::string& s) {
-	return std::wstring_convert<std::codecvt_utf8<wchar_t>>()
-		.from_bytes(s);
+	return std::wstring_convert<std::codecvt_utf8<wchar_t>>().from_bytes(s);
 }
+
 string ws2s(const wstring& s) {
-	return std::wstring_convert<std::codecvt_utf8<wchar_t>>()
-		.to_bytes(s);
+	return std::wstring_convert<std::codecvt_utf8<wchar_t>>().to_bytes(s);
 }
 
 int main() {
@@ -31,9 +30,8 @@ int main() {
 	output::create(L"output",   L".out",    L"@stdout");
 	output::create(L"errors",   L".err",    L"@stderr");
 	output::create(L"buffer",   L".buff",   L"@buffer");
-	output::create(L"tmp",      L".tmp",    L"@tmp");
 	output::create(L"file",     L".file",   L"test.file");
-	output::create(L"noname", L".noname", L"@name");
+	output::create(L"noname",   L".noname", L"@name");
 	output::set_name(L"named");
 	output::create(L"name1",    L".name1",  L"@name");
 	output::create(L"name2",    L".name2",  L"@name");
@@ -53,26 +51,15 @@ int main() {
 	wcout<<L"buffer content: \""<<output::read(L"buffer")<<L'"'<<endl;
 	assert(output::read(L"buffer") == L"buffer test");
 
-	// output to tmp file
-	output::to(L"tmp") << L"tmp test" << endl;
-
 	// output to file
 	output::to(L"file") << L"file test" << endl;
-
-	// output to named file w/o specifying the name => tmp file
-	output::to(L"noname") << L"noname test" << endl;
 
 	// output to named files
 	output::to(L"name1") << L"named1 test" << endl;
 	output::to(L"name2") << L"named2 test" << endl;
 
-	// get known
-	wcout<<L"get returns output*: "<<output::get(L"output")<<endl;
-	assert(output::get(L"output"));
-
-	// get unkown
-	wcout<<L"get unknown output: "<<output::get(L"not created")<<endl;
-	assert(!output::get(L"not created"));
+	// output to undefined output
+	output::to(L"undef") << L"named2 test" << endl;
 
 	// get filename outputs target to
 	wcout << L"outputs to files:" << endl;
@@ -80,20 +67,18 @@ int main() {
 	wcout << L"\t output: " << output::file(L"output") << endl;
 	wcout << L"\t errors: " << output::file(L"errors") << endl;
 	wcout << L"\t buffer: " << output::file(L"buffer") << endl;
-	wcout << L"\t tmp: "    << output::file(L"tmp")    << endl;
-	wcout << L"\t noname: " << output::file(L"noname") << endl;
 	wcout << L"\t name1: "  << output::file(L"name1")  << endl;
 	wcout << L"\t name2: "  << output::file(L"name2")  << endl;
 	wcout << L"\t file: "   << output::file(L"file")   << endl;
+	wcout << L"\t undef: "  << output::file(L"undef")  << endl;
 	assert(output::file(L"null")   == L"");
 	assert(output::file(L"output") == L"");
 	assert(output::file(L"errors") == L"");
 	assert(output::file(L"buffer") == L"");
-	assert(output::file(L"tmp")    != L"");
-	assert(output::file(L"noname") != L"");
 	assert(output::file(L"name1")  == L"named.name1");
 	assert(output::file(L"name2")  == L"named.name2");
 	assert(output::file(L"file")   == L"test.file");
+	assert(output::file(L"undef")  == L"");
 
 	// is null
 	wcout << L"is_null?:" << endl;
@@ -101,20 +86,18 @@ int main() {
 	wcout << L"\t output: " << output::is_null(L"output") << endl;
 	wcout << L"\t errors: " << output::is_null(L"errors") << endl;
 	wcout << L"\t buffer: " << output::is_null(L"buffer") << endl;
-	wcout << L"\t tmp: "    << output::is_null(L"tmp")    << endl;
-	wcout << L"\t noname: " << output::is_null(L"noname") << endl;
 	wcout << L"\t name1: "  << output::is_null(L"name1")  << endl;
 	wcout << L"\t name2: "  << output::is_null(L"name2")  << endl;
 	wcout << L"\t file: "   << output::is_null(L"file")   << endl;
+	wcout << L"\t undef: "  << output::is_null(L"undef")  << endl;
 	assert( output::is_null(L"null"));
 	assert(!output::is_null(L"output"));
 	assert(!output::is_null(L"errors"));
 	assert(!output::is_null(L"buffer"));
-	assert(!output::is_null(L"tmp"));
-	assert(!output::is_null(L"noname"));
 	assert(!output::is_null(L"name1"));
 	assert(!output::is_null(L"name2"));
 	assert(!output::is_null(L"file"));
+	assert( output::is_null(L"undef"));
 
 	// get targets
 	wcout << L"targets:" << endl;
@@ -122,18 +105,23 @@ int main() {
 	wcout << L"\t output: " << output::get_target(L"output") << endl;
 	wcout << L"\t errors: " << output::get_target(L"errors") << endl;
 	wcout << L"\t buffer: " << output::get_target(L"buffer") << endl;
-	wcout << L"\t tmp: "    << output::get_target(L"tmp")    << endl;
-	wcout << L"\t noname: " << output::get_target(L"noname") << endl;
 	wcout << L"\t name1: "  << output::get_target(L"name1")  << endl;
 	wcout << L"\t name2: "  << output::get_target(L"name2")  << endl;
 	wcout << L"\t file: "   << output::get_target(L"file")   << endl;
+	wcout << L"\t undef: "  << output::get_target(L"undef")  << endl;
 	assert(output::get_target(L"null")   == L"@null");
 	assert(output::get_target(L"output") == L"@stdout");
 	assert(output::get_target(L"errors") == L"@stderr");
 	assert(output::get_target(L"buffer") == L"@buffer");
-	assert(output::get_target(L"tmp")    == L"@tmp");
-	assert(output::get_target(L"noname") == L"@name");
 	assert(output::get_target(L"name1")  == L"@name");
 	assert(output::get_target(L"name2")  == L"@name");
 	assert(output::get_target(L"file")   == L"test.file");
+	assert(output::get_target(L"undef")  == L"@null");
+
+	output o;
+	// getting existing output returns true and returns output by ref.
+	assert(output::get(L"output", o));
+	wcout<<L"get returns output: "<<o<<endl;
+	// getting non existing output returns false
+	assert(!output::get(L"undef", o));
 }

--- a/src/print_prolog.cpp
+++ b/src/print_prolog.cpp
@@ -35,7 +35,7 @@ wostream& driver::print_swipl(wostream& os, const raw_prog& rp) const {
 }
 
 wostream& driver::print_prolog(wostream& os, const raw_prog& p,
-	const dialect d) const {
+	const prolog_dialect d) const {
 	relarities ras;
 	get_relarities(p, ras);
 	wstring name = d == SWIPL ? L"SWI Prolog" : L"XSB";

--- a/src/save_csv.cpp
+++ b/src/save_csv.cpp
@@ -11,22 +11,18 @@
 // Contact ohad@idni.org for requesting a permission. This license may be
 // modified over time by the Author.
 #include <fstream>
-#include <locale>
-#include <codecvt>
 #include "driver.h"
 using namespace std;
 
 void driver::save_csv() const {
 	map<elem, wofstream> files;
-	using convert_type = std::codecvt_utf8<wchar_t>;
-	wstring_convert<convert_type, wchar_t> converter;
-	tbl.out([&files, &converter](const raw_term& t) {
+	tbl.out([&files](const raw_term& t) {
 		auto it = files.find(t.e[0]);
 		if (it == files.end()) {
 			wstring wfname = lexeme2str(t.e[0].e) + L".csv";
 			wcerr << L"Saving " << wfname << endl;
 			files.emplace(t.e[0],
-				wofstream(converter.to_bytes(wfname)));
+				wofstream(ws2s(wfname)));
 			it = files.find(t.e[0]);
 		}
 		wofstream& os = it->second;

--- a/src/test_output.sh
+++ b/src/test_output.sh
@@ -1,29 +1,27 @@
 #!/bin/bash
 
-g++ output.test.cpp -DDEBUG && ./a.out >test_output.stdout 2>test_output.stderr
+g++ -W -Wall -Wextra -Wpedantic -g -DDEBUG -std=gnu++17 output.test.cpp \
+	&& ./a.out >test_output.stdout 2>test_output.stderr || exit
 
-OUTPUT=`head -n 1 test_output.stdout`
-[ "$OUTPUT" == "stdout test" ] && echo "output ok" || echo "output not ok"
+OUTPUT=`head -n 1 test_output.stdout` && [ "$OUTPUT" == "stdout test" ] \
+	&& echo "output ok" || echo "output not ok"
 
-TMP=`head -n 1 test_output.stderr | sed 's/\s.*//g'`
-TMP_CONTENT=`cat $TMP`
-[ "$TMP_CONTENT" == "tmp test" ] && echo "tmp ok" || echo "tmp not ok"
+ERRORS=`cat test_output.stderr` && \
+[ "$ERRORS" == "output 'noname' targeting @name without name
+stderr test" ] \
+	&& echo "stderr ok" || echo "stderr not ok"
 
-NONAMED=`head -n 2 test_output.stderr | tail -n 1 | sed 's/\s.*//g'`
-NONAMED_CONTENT=`cat $NONAMED`
-[ "$NONAMED_CONTENT" == "noname test" ] && echo "noname ok" || echo "noname not ok"
+NAME1_CONTENT=`cat named.name1` && [ "$NAME1_CONTENT" == "named1 test" ] \
+	&& echo "name1 ok" || echo "name1 not ok"
 
-NAME1_CONTENT=`cat named.name1`
-[ "$NAME1_CONTENT" == "named1 test" ] && echo "name1 ok" || echo "name1 not ok"
-
-NAME2_CONTENT=`cat named.name2`
-[ "$NAME2_CONTENT" == "named2 test" ] && echo "name2 ok" || echo "name2 not ok"
+NAME2_CONTENT=`cat named.name2` && [ "$NAME2_CONTENT" == "named2 test" ] \
+	&& echo "name2 ok" || echo "name2 not ok"
 
 FILE_CONTENT=`cat test.file`
-[ "$FILE_CONTENT" == "file test" ] && echo "file ok" || echo "file not ok"
+[ "$FILE_CONTENT" == "file test" ] \
+	&& echo "file ok" || echo "file not ok"
 
-echo
-cat test_output.stdout
+echo && echo "STDERR:" && cat test_output.stderr
+echo && echo "STDOUT:" && cat test_output.stdout
 
-rm a.out test_output.stdout test_output.stderr named.name1 named.name2 \
-	test.file $TMP $NONAMED
+rm a.out test_output.stdout test_output.stderr named.name1 named.name2 test.file

--- a/src/test_output.sh
+++ b/src/test_output.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+g++ output.test.cpp -DDEBUG && ./a.out >test_output.stdout 2>test_output.stderr
+
+OUTPUT=`head -n 1 test_output.stdout`
+[ "$OUTPUT" == "stdout test" ] && echo "output ok" || echo "output not ok"
+
+TMP=`head -n 1 test_output.stderr | sed 's/\s.*//g'`
+TMP_CONTENT=`cat $TMP`
+[ "$TMP_CONTENT" == "tmp test" ] && echo "tmp ok" || echo "tmp not ok"
+
+NONAMED=`head -n 2 test_output.stderr | tail -n 1 | sed 's/\s.*//g'`
+NONAMED_CONTENT=`cat $NONAMED`
+[ "$NONAMED_CONTENT" == "noname test" ] && echo "noname ok" || echo "noname not ok"
+
+NAME1_CONTENT=`cat named.name1`
+[ "$NAME1_CONTENT" == "named1 test" ] && echo "name1 ok" || echo "name1 not ok"
+
+NAME2_CONTENT=`cat named.name2`
+[ "$NAME2_CONTENT" == "named2 test" ] && echo "name2 ok" || echo "name2 not ok"
+
+FILE_CONTENT=`cat test.file`
+[ "$FILE_CONTENT" == "file test" ] && echo "file ok" || echo "file not ok"
+
+echo
+cat test_output.stdout
+
+rm a.out test_output.stdout test_output.stderr named.name1 named.name2 \
+	test.file $TMP $NONAMED

--- a/src/test_vs_swipl.sh
+++ b/src/test_vs_swipl.sh
@@ -4,9 +4,9 @@ DIFF=""
 while [ "$DIFF" == "" ]
 do
 	INPUT=`./a.out`
+	OUTPUT="program.swipl"
 	echo $INPUT
-	./tml --swipl < $INPUT > tml.output 2> tml.fname
-	OUTPUT=`head -n 1 tml.fname | awk 'NF>1{print $NF}'`
+	./tml --swipl $OUTPUT < $INPUT > tml.output 2> tml.fname
 	echo $OUTPUT
 	timeout 5 swipl $OUTPUT > swipl.output 2> /dev/null
 	if [ $? -eq 124 ]; then


### PR DESCRIPTION
- s2ws and ws2s with utf8 convertor

OPTIONS:
- works with one or two hyphens
- alternative names (short names)
- configured in `options::setup()`
- output's target configurable by string option with the same name as output's
- default options: `--run true --output @stdout` (configured in `options::init_defaults()`)
- bool option is true if: true, t, 1, on, enabled or if no value provided
- disabling (making false) option (`--run` for example) can be alternatively done by: `--disable-run`, `--no-run` or `--dont-run`

OUTPUTS:
- removed temporary files (I can re-add if required)
- possible targets: `@null`, `@stdout`, `@stderr`, `@name`, `@buffer`, `filename`.
If no value provided enabled output targets `@stdout` 
- option `--name` can be used for naming all outputs targeting `@name`. it adds unique extension to each output.
Example: `./tml --name test123 -o @name -ast-html @name -t @name < program.tml`
will save output into `test123.out.tml`, HTML AST into `test123.ast.html` and transformed program into `test123.trans.tml`
- output streams and their default extensions are - created in `driver::init()`:
  - output (.out.tml)
  - transformed (.trans.tml)
  - xsb (.P)
  - swipl (.pl)
  - souffle (.souffle)
  - ast (.ast.tml)
  - ast-json (.ast.json)
  - ast-xml (.ast.xml)
  - ast-html (.ast.html)

AST:
- fixed XML/HTML iterator out of bounds
- TML (`--ast`): each ast node type has its own relation now